### PR TITLE
Add basic Node test for formatDate

### DIFF
--- a/formatDate.js
+++ b/formatDate.js
@@ -1,0 +1,10 @@
+function formatDate(iso) {
+  const d = new Date(iso);
+  return d.toLocaleDateString(undefined, {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+module.exports = formatDate;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "nepobabiesruntheunderground",
+  "version": "1.0.0",
+  "type": "commonjs",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/tests/formatDate.test.js
+++ b/tests/formatDate.test.js
@@ -1,0 +1,10 @@
+const formatDate = require('../formatDate');
+const assert = require('assert');
+const test = require('node:test');
+
+test('formatDate returns a non-empty string containing 2025', () => {
+  const result = formatDate('2025-07-15');
+  assert.strictEqual(typeof result, 'string');
+  assert.notStrictEqual(result.length, 0);
+  assert.ok(result.includes('2025'));
+});


### PR DESCRIPTION
## Summary
- implement `formatDate.js` for node usage
- add a node:test verifying that the return contains `2025`
- add minimal `package.json` with test script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d18d762208321b146cd43138de783