### PR TITLE
Refactor to use shared date helper

### DIFF
--- a/me.html
+++ b/me.html
@@ -71,15 +71,7 @@
     if (nearBottom) loadPosts();
   }
 
-  function formatDate(iso) {
-    /* optional: prettify ISO date → "15 Jul 2025" */
-    const d = new Date(iso);
-    return d.toLocaleDateString(undefined, {
-      day: "2-digit",
-      month: "short",
-      year: "numeric",
-    });
-  }
-</script>
-</body>
-</html>
+  </script>
+  <script src="formatDate.js"></script>
+  </body>
+  </html>


### PR DESCRIPTION
## Summary
- remove the inline `formatDate` helper from `me.html`
- load the shared `formatDate.js` script instead

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d1cf5096083219840f13b4981f1d2