### PR TITLE
Add PixiJS draggable canvas tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 
 package-lock.json
+node_modules/

--- a/package.json
+++ b/package.json
@@ -4,5 +4,11 @@
   "type": "commonjs",
   "scripts": {
     "test": "node --test"
+  },
+  "dependencies": {
+    "pixi.js": "^8.11.0"
+  },
+  "devDependencies": {
+    "puppeteer": "^24.15.0"
   }
 }

--- a/tests/toolPage.test.js
+++ b/tests/toolPage.test.js
@@ -1,0 +1,50 @@
+const path = require('path');
+const { test } = require('node:test');
+const assert = require('assert');
+const puppeteer = require('puppeteer');
+
+const filePath = path.join(__dirname, '..', 'tool.html');
+const url = 'file://' + filePath;
+
+async function setup() {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--allow-file-access-from-files', '--no-sandbox', '--disable-setuid-sandbox']
+  });
+  const page = await browser.newPage();
+  await page.goto(url);
+  return { browser, page };
+}
+
+// drag test
+test('dragging moves world container', async (t) => {
+  const { browser, page } = await setup();
+  await page.waitForFunction(() => window.world); // ensure world is ready
+  const start = await page.evaluate(() => ({ x: window.world.x, y: window.world.y }));
+  const canvasSelector = 'canvas';
+  const rect = await page.$eval(canvasSelector, el => {
+    const r = el.getBoundingClientRect();
+    return { x: r.left, y: r.top, width: r.width, height: r.height };
+  });
+  await page.mouse.move(rect.x + 100, rect.y + 100);
+  await page.mouse.down();
+  await page.mouse.move(rect.x + 150, rect.y + 150);
+  await page.mouse.up();
+  const end = await page.evaluate(() => ({ x: window.world.x, y: window.world.y }));
+  assert.ok(end.x !== start.x || end.y !== start.y);
+  await browser.close();
+});
+
+// upload test
+test('uploading image adds sprite', async (t) => {
+  const { browser, page } = await setup();
+  await page.waitForFunction(() => window.world);
+  const initialCount = await page.evaluate(() => window.world.children.length);
+  const input = await page.$('#file-input');
+  const imgPath = path.join(__dirname, '..', 'assets', 'images', 'favicon.png');
+  await input.uploadFile(imgPath);
+  await page.waitForFunction(() => window.world.children.length > 0);
+  const finalCount = await page.evaluate(() => window.world.children.length);
+  assert.ok(finalCount > initialCount);
+  await browser.close();
+});

--- a/tool.html
+++ b/tool.html
@@ -44,14 +44,16 @@
     </label>
   </div>
   <script type="module">
-    import { Application, Container, Sprite } from 'https://unpkg.com/pixi.js@8/dist/pixi.min.mjs';
+    import { Application, Container, Sprite } from './node_modules/pixi.js/dist/pixi.min.mjs';
 
     const app = new Application();
     await app.init({ resizeTo: window, background: '#222' });
     document.body.appendChild(app.canvas);
+    window.app = app;
 
     const world = new Container();
     app.stage.addChild(world);
+    window.world = world;
 
     let isDragging = false;
     let lastX = 0;

--- a/tool.html
+++ b/tool.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tool</title>
+  <style>
+    html, body {
+      margin: 0;
+      height: 100%;
+      overflow: hidden;
+      background: #111;
+    }
+    canvas { width: 100%; height: 100%; display: block; }
+    #menu-button {
+      position: fixed;
+      top: 10px;
+      right: 10px;
+      width: 32px;
+      height: 32px;
+      background: url('assets/images/favicon.png') no-repeat center/contain;
+      cursor: pointer;
+      z-index: 10;
+    }
+    #menu {
+      position: fixed;
+      top: 50px;
+      right: 10px;
+      background: rgba(255,255,255,0.95);
+      padding: 8px;
+      border-radius: 4px;
+      display: none;
+      z-index: 10;
+    }
+    #menu.show { display: block; }
+  </style>
+</head>
+<body>
+  <div id="menu-button" title="Menu"></div>
+  <div id="menu">
+    <label>
+      Upload Image
+      <input type="file" id="file-input" accept="image/*">
+    </label>
+  </div>
+  <script type="module">
+    import { Application, Container, Sprite } from 'https://unpkg.com/pixi.js@8/dist/pixi.min.mjs';
+
+    const app = new Application();
+    await app.init({ resizeTo: window, background: '#222' });
+    document.body.appendChild(app.canvas);
+
+    const world = new Container();
+    app.stage.addChild(world);
+
+    let isDragging = false;
+    let lastX = 0;
+    let lastY = 0;
+
+    app.canvas.addEventListener('pointerdown', (e) => {
+      isDragging = true;
+      lastX = e.clientX;
+      lastY = e.clientY;
+      app.canvas.style.cursor = 'grabbing';
+    });
+
+    window.addEventListener('pointerup', () => {
+      isDragging = false;
+      app.canvas.style.cursor = 'default';
+    });
+
+    window.addEventListener('pointermove', (e) => {
+      if (!isDragging) return;
+      world.x += e.clientX - lastX;
+      world.y += e.clientY - lastY;
+      lastX = e.clientX;
+      lastY = e.clientY;
+    });
+
+    app.canvas.addEventListener('wheel', (e) => {
+      e.preventDefault();
+      const scaleFactor = e.deltaY < 0 ? 1.1 : 0.9;
+      const rect = app.canvas.getBoundingClientRect();
+      const mx = e.clientX - rect.left;
+      const my = e.clientY - rect.top;
+      const worldX = (mx - world.x) / world.scale.x;
+      const worldY = (my - world.y) / world.scale.y;
+      const newScale = world.scale.x * scaleFactor;
+      world.scale.set(newScale);
+      world.x = mx - worldX * newScale;
+      world.y = my - worldY * newScale;
+    });
+
+    document.getElementById('file-input').addEventListener('change', (event) => {
+      const file = event.target.files[0];
+      if (!file) return;
+      const url = URL.createObjectURL(file);
+      const sprite = Sprite.from(url);
+      sprite.anchor.set(0.5);
+      sprite.x = app.screen.width / 2;
+      sprite.y = app.screen.height / 2;
+      world.addChild(sprite);
+    });
+
+    const menuButton = document.getElementById('menu-button');
+    const menu = document.getElementById('menu');
+    menuButton.addEventListener('click', () => {
+      menu.classList.toggle('show');
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add new page `tool.html` with pixi.js draggable canvas
- include minimal menu dropdown for image uploads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d2becb48c8321b63aa5aaeffb8177