### PR TITLE
Update tool for multi-image editing

### DIFF
--- a/tool.html
+++ b/tool.html
@@ -52,52 +52,73 @@
   <div id="menu-button" title="Menu"></div>
   <div id="menu">
     <label>
-      Upload Image
-      <input type="file" id="file-input" accept="image/*">
+      Upload Images
+      <input type="file" id="file-input" multiple accept="image/*">
     </label>
-    <button id="create-sprite" disabled>Create Sprite</button>
+    <button id="create-sprites" disabled>Create Sprites</button>
+    <br>
+    <label>
+      Blend Mode
+      <select id="blend-mode">
+        <option value="NORMAL">Normal</option>
+        <option value="ADD">Add</option>
+        <option value="MULTIPLY">Multiply</option>
+        <option value="SCREEN">Screen</option>
+        <option value="OVERLAY">Overlay</option>
+      </select>
+    </label>
+    <br>
+    <label>
+      Exposure
+      <input type="range" id="exposure" min="-1" max="1" step="0.05" value="0">
+    </label>
+    <br>
+    <button id="randomize">Randomize</button>
     <br><br>
     <button id="reset-view">Reset View</button>
     <button id="clear-all">Clear All</button>
   </div>
   <div id="mouse-pos">Mouse: (0, 0)</div>
   <script type="module">
-    import { Application, Container, Sprite, Graphics, Texture } from 'https://cdn.jsdelivr.net/npm/pixi.js@8.11.0/dist/pixi.min.mjs';
+    import {
+      Application,
+      Container,
+      Sprite,
+      Graphics,
+      Texture,
+      BLEND_MODES,
+      filters
+    } from 'https://cdn.jsdelivr.net/npm/pixi.js@8.11.0/dist/pixi.min.mjs';
 
     const app = new Application();
     await app.init({ resizeTo: window, background: '#222' });
     document.body.appendChild(app.canvas);
-    window.app = app;
 
     const world = new Container();
     app.stage.addChild(world);
-    window.world = world;
 
-    // Create a visual boundary box to show sprite spawn area
     const spawnArea = new Graphics();
-    spawnArea.rect(-400, -300, 800, 600); // 800x600 area centered at origin
-    spawnArea.stroke({ color: 0x00ff00, width: 2 }); // Green border
-    spawnArea.fill({ color: 0x000000, alpha: 0.1 }); // Semi-transparent black fill
+    spawnArea.rect(-400, -300, 800, 600);
+    spawnArea.stroke({ color: 0x00ff00, width: 2 });
+    spawnArea.fill({ color: 0x000000, alpha: 0.1 });
     world.addChild(spawnArea);
 
-    // Add coordinate markers
-    const centerMarker = new Graphics();
-    centerMarker.circle(0, 0, 5);
-    centerMarker.fill({ color: 0xff0000 }); // Red dot at center
-    world.addChild(centerMarker);
-
-    // Add axis lines
     const axisLines = new Graphics();
-    axisLines.moveTo(-400, 0).lineTo(400, 0); // X-axis
-    axisLines.moveTo(0, -300).lineTo(0, 300); // Y-axis
+    axisLines.moveTo(-400, 0).lineTo(400, 0);
+    axisLines.moveTo(0, -300).lineTo(0, 300);
     axisLines.stroke({ color: 0x666666, width: 1 });
     world.addChild(axisLines);
 
-    console.log('Spawn area created: 800x600 centered at (0,0)');
+    const centerMarker = new Graphics();
+    centerMarker.circle(0, 0, 5);
+    centerMarker.fill({ color: 0xff0000 });
+    world.addChild(centerMarker);
 
     const mousePosDisplay = document.getElementById('mouse-pos');
 
-    let selectedFile = null;
+    const sprites = [];
+    let selectedFiles = [];
+    const exposureFilter = new filters.ColorMatrixFilter();
 
     let isDragging = false;
     let lastX = 0;
@@ -116,15 +137,17 @@
     });
 
     window.addEventListener('pointermove', (e) => {
-      // Update mouse position display
       const rect = app.canvas.getBoundingClientRect();
       const canvasX = e.clientX - rect.left;
       const canvasY = e.clientY - rect.top;
       const worldX = (canvasX - world.x) / world.scale.x;
       const worldY = (canvasY - world.y) / world.scale.y;
-      
-      mousePosDisplay.textContent = `Mouse: Screen(${e.clientX}, ${e.clientY}) Canvas(${Math.round(canvasX)}, ${Math.round(canvasY)}) World(${Math.round(worldX)}, ${Math.round(worldY)})`;
-      
+
+      mousePosDisplay.textContent =
+        `Mouse: Screen(${e.clientX}, ${e.clientY}) ` +
+        `Canvas(${Math.round(canvasX)}, ${Math.round(canvasY)}) ` +
+        `World(${Math.round(worldX)}, ${Math.round(worldY)})`;
+
       if (!isDragging) return;
       world.x += e.clientX - lastX;
       world.y += e.clientY - lastY;
@@ -146,88 +169,67 @@
       world.y = my - worldY * newScale;
     });
 
-    document.getElementById('file-input').addEventListener('change', (event) => {
-      const file = event.target.files[0];
-      if (!file) {
-        selectedFile = null;
-        document.getElementById('create-sprite').disabled = true;
-        return;
-      }
-      selectedFile = file;
-      document.getElementById('create-sprite').disabled = false;
+    const fileInput = document.getElementById('file-input');
+    const createBtn = document.getElementById('create-sprites');
+    const blendSelect = document.getElementById('blend-mode');
+    const exposureInput = document.getElementById('exposure');
+    const randomizeBtn = document.getElementById('randomize');
+
+    fileInput.addEventListener('change', (event) => {
+      selectedFiles = Array.from(event.target.files);
+      createBtn.disabled = selectedFiles.length === 0;
     });
 
-    document.getElementById('create-sprite').addEventListener('click', () => {
-      if (!selectedFile) return;
-      
-      console.log('Starting sprite creation...');
-      
-      // Create a simple test sprite first
-      const testGraphics = new Graphics();
-      testGraphics.circle(0, 0, 50);
-      testGraphics.fill({ color: 0xff00ff }); // Magenta circle
-      world.addChild(testGraphics);
-      console.log('Added test graphics circle at (0,0)');
-      
-      // Create placeholder sprite while image loads
-      const placeholder = new Graphics();
-      placeholder.rect(-50, -25, 100, 50);
-      placeholder.fill({ color: 0x00ffff }); // Cyan rectangle
-      placeholder.x = 100;
-      placeholder.y = 0;
-      world.addChild(placeholder);
-      console.log('Added cyan placeholder at (100, 0)');
-      
-      // Method 1: Try loading image via HTML Image element first
-      const img = new Image();
-      img.crossOrigin = 'anonymous';
-      
-      img.onload = () => {
-        console.log('HTML Image loaded successfully:', {
-          width: img.width,
-          height: img.height,
-          src: img.src
-        });
-        
-        // Create PIXI texture from loaded image using correct v8 API
-        const texture = Texture.from(img);
-        const sprite = new Sprite(texture);
-        
-        sprite.anchor.set(0.5);
-        sprite.x = 200; // Further right
-        sprite.y = 0;
-        sprite.scale.set(0.5);
-        
-        world.addChild(sprite);
-        world.removeChild(placeholder); // Remove placeholder
-        
-        console.log('Image sprite created successfully at (200, 0)');
-      };
-      
-      img.onerror = (error) => {
-        console.error('HTML Image loading failed:', error);
-        
-        // Fallback: Try PIXI's built-in loader
-        const url = URL.createObjectURL(selectedFile);
-        console.log('Trying PIXI loader with URL:', url);
-        
-        const sprite = Sprite.from(url);
-        sprite.anchor.set(0.5);
-        sprite.x = 300; // Even further right
-        sprite.y = 0;
-        sprite.scale.set(0.5);
-        
-        world.addChild(sprite);
-        
-        console.log('PIXI sprite created as fallback at (300, 0)');
-      };
-      
-      // Start loading
-      const url = URL.createObjectURL(selectedFile);
-      img.src = url;
-      
-      console.log('Started loading image from:', url);
+    function applyExposure() {
+      const value = parseFloat(exposureInput.value);
+      exposureFilter.reset();
+      exposureFilter.brightness(value + 1, false);
+      sprites.forEach((s) => {
+        s.filters = [exposureFilter];
+      });
+    }
+
+    function createSprites() {
+      selectedFiles.forEach((file) => {
+        const img = new Image();
+        img.onload = () => {
+          const texture = Texture.from(img);
+          const sprite = new Sprite(texture);
+          sprite.anchor.set(0.5);
+          sprite.x = Math.random() * 800 - 400;
+          sprite.y = Math.random() * 600 - 300;
+          sprite.scale.set(0.3 + Math.random() * 0.7);
+          sprite.blendMode = BLEND_MODES[blendSelect.value];
+          sprite.filters = [exposureFilter];
+          sprites.push(sprite);
+          world.addChild(sprite);
+        };
+        img.src = URL.createObjectURL(file);
+      });
+      selectedFiles = [];
+      fileInput.value = '';
+      createBtn.disabled = true;
+    }
+
+    function randomizeSprites() {
+      sprites.forEach((sprite) => {
+        sprite.x = Math.random() * 800 - 400;
+        sprite.y = Math.random() * 600 - 300;
+        sprite.scale.set(0.3 + Math.random() * 0.7);
+        const modes = Object.keys(BLEND_MODES);
+        const randMode = modes[Math.floor(Math.random() * modes.length)];
+        sprite.blendMode = BLEND_MODES[randMode];
+      });
+    }
+
+    createBtn.addEventListener('click', createSprites);
+    blendSelect.addEventListener('change', () => {
+      sprites.forEach((s) => {
+        s.blendMode = BLEND_MODES[blendSelect.value];
+      });
     });
+    exposureInput.addEventListener('input', applyExposure);
+    randomizeBtn.addEventListener('click', randomizeSprites);
 
     const menuButton = document.getElementById('menu-button');
     const menu = document.getElementById('menu');
@@ -235,22 +237,18 @@
       menu.classList.toggle('show');
     });
 
-    // Reset view button
     document.getElementById('reset-view').addEventListener('click', () => {
       world.x = app.screen.width / 2;
       world.y = app.screen.height / 2;
       world.scale.set(1);
-      console.log('View reset to center');
     });
 
-    // Clear all sprites button
     document.getElementById('clear-all').addEventListener('click', () => {
-      // Remove all children except the first 3 (spawn area, center marker, axis lines)
-      while (world.children.length > 3) {
-        world.removeChildAt(world.children.length - 1);
-      }
-      console.log('All sprites cleared, spawn area preserved');
+      sprites.forEach((s) => world.removeChild(s));
+      sprites.length = 0;
     });
+
+    applyExposure();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expand tool menu UI for multiple image uploads
- add blend mode dropdown and exposure slider
- randomize sprite placement and mode
- support multi-file uploads and global updates to existing sprites

## Testing
- `npm test` *(fails: waiting for puppeteer due to blocked CDN access)*

------
https://chatgpt.com/codex/tasks/task_e_688d45bd9f108321ab3726bbfb8d1191