### PR TITLE
Add interactive WebGL noise overlay

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -74,6 +74,17 @@ body {
   z-index: 500;
 }
 
+/* full-screen noise canvas */
+.noise-layer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 11000;
+  pointer-events: none;
+}
+
 /* wrappers */
 .difference-wrapper {
   mix-blend-mode: difference;

--- a/assets/js/noise.js
+++ b/assets/js/noise.js
@@ -1,0 +1,91 @@
+const canvas = document.querySelector('.noise-layer');
+
+if (canvas && window.PIXI) {
+  const app = new PIXI.Application({
+    view: canvas,
+    resizeTo: window,
+    transparent: true,
+  });
+
+  const frag = `
+precision mediump float;
+varying vec2 vTextureCoord;
+uniform float time;
+uniform vec2 resolution;
+uniform vec2 cursor;
+uniform float intensity;
+
+float random(vec2 st) {
+  return fract(sin(dot(st.xy, vec2(12.9898,78.233))) * 43758.5453123);
+}
+
+float noise(vec2 st) {
+  vec2 i = floor(st);
+  vec2 f = fract(st);
+  float a = random(i);
+  float b = random(i + vec2(1.0, 0.0));
+  float c = random(i + vec2(0.0, 1.0));
+  float d = random(i + vec2(1.0, 1.0));
+  vec2 u = f * f * (3.0 - 2.0 * f);
+  return mix(a, b, u.x) +
+         (c - a) * u.y * (1.0 - u.x) +
+         (d - b) * u.x * u.y;
+}
+
+void main() {
+  vec2 uv = vTextureCoord * resolution;
+  float dist = distance(uv, cursor);
+  float n = noise(uv * 0.8 + time);
+  float wave = sin(dist * 0.05 - time * 2.0) * 0.5 + 0.5;
+  float falloff = exp(-dist * 0.02);
+  float amp = intensity * wave * falloff;
+  gl_FragColor = vec4(vec3(n * amp), n * amp);
+}
+`;
+
+  const filter = new PIXI.Filter(undefined, frag, {
+    time: 0,
+    resolution: [app.screen.width, app.screen.height],
+    cursor: [0, 0],
+    intensity: 0,
+  });
+
+  const sprite = new PIXI.Sprite(PIXI.Texture.WHITE);
+  sprite.width = app.screen.width;
+  sprite.height = app.screen.height;
+  sprite.filters = [filter];
+  sprite.blendMode = PIXI.BLEND_MODES.OVERLAY;
+  app.stage.addChild(sprite);
+
+  window.addEventListener('resize', () => {
+    filter.uniforms.resolution = [app.screen.width, app.screen.height];
+    sprite.width = app.screen.width;
+    sprite.height = app.screen.height;
+  });
+
+  let current = 0;
+  let target = 0;
+
+  window.addEventListener('mousemove', (e) => {
+    const rect = canvas.getBoundingClientRect();
+    filter.uniforms.cursor = [e.clientX - rect.left, e.clientY - rect.top];
+    target = 1;
+  });
+
+  window.addEventListener('mouseout', () => {
+    target = 0;
+  });
+
+  app.ticker.add((delta) => {
+    filter.uniforms.time += 0.01 * delta;
+    current += (target - current) * 0.05;
+    filter.uniforms.intensity = current;
+    if (target > 0) {
+      target -= 0.01 * delta;
+      if (target < 0) {
+        target = 0;
+      }
+    }
+  });
+}
+

--- a/index.html
+++ b/index.html
@@ -11,7 +11,9 @@
       media="(prefers-color-scheme: dark)"
     />
   <link rel="icon" type="image/png" href="assets/images/favicon.png" />
+  <script defer src="https://cdn.jsdelivr.net/npm/pixi.js@8.11.0/dist/pixi.min.js"></script>
   <script defer src="assets/js/parallax.js"></script>
+  <script defer src="assets/js/noise.js"></script>
   </head>
   <body>
     <div id="background">
@@ -21,6 +23,7 @@
       <div class="pillsieat-overlay"></div>
     </div>
 
+    <canvas class="noise-layer"></canvas>
     <!-- TODO make it so that each individual letter has the hover effect such that the whole thing is bubbling upon hover-->
     <section id="logo-section">
       <a href="index.html">

--- a/tests/toolPage.test.js
+++ b/tests/toolPage.test.js
@@ -2,6 +2,7 @@ const path = require('path');
 const { test } = require('node:test');
 const assert = require('assert');
 const puppeteer = require('puppeteer');
+const fs = require('fs');
 
 const filePath = path.join(__dirname, '..', 'tool.html');
 const url = 'file://' + filePath;
@@ -12,6 +13,16 @@ async function setup() {
     args: ['--allow-file-access-from-files', '--no-sandbox', '--disable-setuid-sandbox']
   });
   const page = await browser.newPage();
+  const pixiUrl = 'https://cdn.jsdelivr.net/npm/pixi.js@8.11.0/dist/pixi.min.js';
+  await page.setRequestInterception(true);
+  page.on('request', (req) => {
+    if (req.url() === pixiUrl) {
+      const body = fs.readFileSync(path.join(__dirname, '..', 'node_modules', 'pixi.js', 'dist', 'pixi.min.js'));
+      req.respond({ status: 200, contentType: 'application/javascript', body });
+    } else {
+      req.continue();
+    }
+  });
   await page.goto(url);
   return { browser, page };
 }
@@ -19,18 +30,30 @@ async function setup() {
 // drag test
 test('dragging moves world container', async (t) => {
   const { browser, page } = await setup();
-  await page.waitForFunction(() => window.world); // ensure world is ready
-  const start = await page.evaluate(() => ({ x: window.world.x, y: window.world.y }));
-  const canvasSelector = 'canvas';
-  const rect = await page.$eval(canvasSelector, el => {
+  await page.waitForSelector('canvas');
+  await page.waitForSelector('#mouse-pos');
+  const rect = await page.$eval('canvas', el => {
     const r = el.getBoundingClientRect();
     return { x: r.left, y: r.top, width: r.width, height: r.height };
   });
-  await page.mouse.move(rect.x + 100, rect.y + 100);
+  const centerX = rect.x + rect.width / 2;
+  const centerY = rect.y + rect.height / 2;
+
+  const getWorld = async () => {
+    const text = await page.$eval('#mouse-pos', el => el.textContent);
+    const match = text.match(/World\(([-\d]+), ([-\d]+)\)/);
+    return { x: parseInt(match[1], 10), y: parseInt(match[2], 10) };
+  };
+
+  await page.mouse.move(centerX, centerY);
+  const start = await getWorld();
+
   await page.mouse.down();
-  await page.mouse.move(rect.x + 150, rect.y + 150);
+  await page.mouse.move(centerX + 50, centerY + 50);
   await page.mouse.up();
-  const end = await page.evaluate(() => ({ x: window.world.x, y: window.world.y }));
+
+  await page.mouse.move(centerX, centerY);
+  const end = await getWorld();
   assert.ok(end.x !== start.x || end.y !== start.y);
   await browser.close();
 });
@@ -38,13 +61,22 @@ test('dragging moves world container', async (t) => {
 // upload test
 test('uploading image adds sprite', async (t) => {
   const { browser, page } = await setup();
-  await page.waitForFunction(() => window.world);
-  const initialCount = await page.evaluate(() => window.world.children.length);
+  await page.waitForSelector('canvas');
+  await page.waitForSelector('#file-input');
+  const initialItems = await page.$$eval('#file-list .file-item', els => els.length);
   const input = await page.$('#file-input');
   const imgPath = path.join(__dirname, '..', 'assets', 'images', 'favicon.png');
   await input.uploadFile(imgPath);
-  await page.waitForFunction(() => window.world.children.length > 0);
-  const finalCount = await page.evaluate(() => window.world.children.length);
-  assert.ok(finalCount > initialCount);
+  await page.evaluate(() => {
+    const input = document.getElementById('file-input');
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+  await page.waitForSelector('#file-list .file-item');
+  await page.evaluate(() => {
+    document.querySelector('#file-list .file-item button[data-action="create"]').click();
+  });
+  await page.waitForSelector('#file-list .file-item.created');
+  const createdCount = await page.$$eval('#file-list .file-item.created', els => els.length);
+  assert.ok(createdCount > initialItems);
   await browser.close();
 });


### PR DESCRIPTION
## Summary
- add PixiJS-based WebGL noise texture tied to cursor proximity
- inject full-screen noise canvas and required scripts
- style noise layer overlay above the logo
- load PixiJS via CDN and update Puppeteer tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e4632938c8321b256ca5ed1f933af