### PR TITLE
Improve image accessibility and link labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,12 +50,13 @@
           <img
             src="assets/images/bassvictim.png"
             class="background_bassvictim"
-            alt="Makes You Wonder"
+            alt="Bassvictim music artist 'Makes You Wonder' single cover"
           />
           <img
             src="assets/images/bassvictim_overlay.png"
             class="overlay_bassvictim"
-            alt="Makes You Wonder"
+            alt=""
+            aria-hidden="true"
           />
           <div class="bassvictim_text">
             <p>INSTAGRAM</p>
@@ -74,36 +75,79 @@
     </section>
 
     <section id="nettspend-parallax">
-      <img src="assets/images/nettspend.gif" alt="" class="drankgif drankdrankdrank" />
-      <img src="assets/images/nettspend_overlay.png" class="drankdrankdrank" />
-      <a href="https://www.last.fm/user/TheTexta">
-        <img src="assets/images/nettspend_overlay.png" class="drankhue drankdrankdrank" />
+      <img
+        src="assets/images/nettspend.gif"
+        alt="Animated Netspend meme"
+        class="drankgif drankdrankdrank"
+      />
+      <img
+        src="assets/images/nettspend_overlay.png"
+        class="drankdrankdrank"
+        alt=""
+        aria-hidden="true"
+      />
+      <a href="https://www.last.fm/user/TheTexta" aria-label="TheTexta on Last.fm">
+        <img
+          src="assets/images/nettspend_overlay.png"
+          class="drankhue drankdrankdrank"
+          alt=""
+          aria-hidden="true"
+        />
       </a>
     </section>
 
     
     <section>
-      <a href="./me.html">
-        <img src="assets/images/me_background.gif" alt="" class="me_background me" loading="lazy" />
-        <img src="assets/images/me_foreground.gif" alt="" class="me_foreground me" loading="lazy" />
-        <img src="assets/images/me_background.gif" alt="" class="me_ultraforeground me" loading="lazy" />
-        <img src="assets/images/me_hover.gif" alt="" class="me_hover me" loading="lazy" />
+      <a href="./me.html" aria-label="About me">
+        <img
+          src="assets/images/me_background.gif"
+          alt=""
+          class="me_background me"
+          loading="lazy"
+          aria-hidden="true"
+        />
+        <img
+          src="assets/images/me_foreground.gif"
+          alt=""
+          class="me_foreground me"
+          loading="lazy"
+          aria-hidden="true"
+        />
+        <img
+          src="assets/images/me_background.gif"
+          alt=""
+          class="me_ultraforeground me"
+          loading="lazy"
+          aria-hidden="true"
+        />
+        <img
+          src="assets/images/me_hover.gif"
+          alt=""
+          class="me_hover me"
+          loading="lazy"
+          aria-hidden="true"
+        />
       </a>
     </section>
 
     <section>
-      <a href="https://open.spotify.com/user/djaydex?si=b02c31c1b8a248ca">
+      <a
+        href="https://open.spotify.com/user/djaydex?si=b02c31c1b8a248ca"
+        aria-label="nepobabiesruntheunderground on Spotify"
+      >
         <img
           src="assets/images/pilleater.png"
           alt=""
           class="pilleater-image"
           id="pilleater-background"
+          aria-hidden="true"
         />
         <img
           src="assets/images/pilleater.png"
           alt=""
           class="pilleater-image-foreground pilleater-image"
           id="pilleater-foreground"
+          aria-hidden="true"
         />
       </a>
     </section>


### PR DESCRIPTION
## Summary
- add descriptive alt text for content images
- hide decorative images from assistive tech
- label image-only links with aria-label
- incorporate review feedback on alt text and link labels

## Testing
- `npm test` *(fails: formatDate is not a function; cannot find module 'puppeteer', 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_688edc618a848321804732eeea53c26a