### PR TITLE
feat: add PWA manifest with acronym short name

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "nepobabies run the underground",
+  "short_name": "NRTU",
+  "start_url": "/index.html",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#000000",
+  "icons": [
+    {
+      "src": "assets/images/favicon.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add web app manifest file
- set PWA short_name to acronym `NRTU`

## Testing
- `npx manifest-validator manifest.json` *(fails: Cannot read properties of undefined (reading 'trim'))*
- `npm test` *(fails: formatDate is not a function; Failed to launch the browser process)*

------
https://chatgpt.com/codex/tasks/task_e_688ee0339c2483218c9cf9b41936d26a