### PR TITLE
Add PWA manifest and service worker

### DIFF
--- a/assets/js/sw-register.js
+++ b/assets/js/sw-register.js
@@ -1,0 +1,5 @@
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js');
+  });
+}

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>nepobabiesruntheunderground</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
+    <link rel="manifest" href="manifest.json" />
     <meta
       name="theme-color"
       content="#ffffff"
@@ -13,6 +14,7 @@
   <link rel="icon" type="image/png" href="assets/images/favicon.png" />
   <script defer src="assets/js/parallax.js"></script>
   <script defer src="assets/js/tvstatic.js"></script>
+  <script defer src="assets/js/sw-register.js"></script>
   </head>
   <body>
     <!-- TV Static overlay canvas with screen blend mode -->

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "nepobabiesruntheunderground",
+  "short_name": "nepobabies",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#000000",
+  "theme_color": "#ffffff",
+  "icons": [
+    {
+      "src": "assets/images/favicon.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "assets/images/favicon.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,22 @@
+const CACHE_NAME = 'nbu-cache-v1';
+const urlsToCache = [
+  '/',
+  '/index.html',
+  '/assets/css/styles.css',
+  '/assets/js/parallax.js',
+  '/assets/js/tvstatic.js',
+  '/assets/js/sw-register.js',
+  '/assets/images/favicon.png'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(urlsToCache))
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  event.respondWith(
+    caches.match(event.request).then((response) => response || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- add web manifest with app name, icons, and theme colors
- register a simple service worker for offline caching
- link manifest and service worker scripts in the site head

## Testing
- `npm test` *(fails: formatDate is not a function; Failed to launch the browser process!)*
- `npx --yes lighthouse http://localhost:8081 --only-categories=pwa --quiet --chrome-flags="--headless"` *(fails: The CHROME_PATH environment variable must be set to a Chrome/Chromium executable)*

------
https://chatgpt.com/codex/tasks/task_e_688edc4e805083218f3fa02dcf478629