### PR TITLE
Use shared formatDate module across scripts and tests

### DIFF
--- a/assets/js/blog.js
+++ b/assets/js/blog.js
@@ -1,15 +1,6 @@
 // Import dependencies
 import "./tvstatic.js";
-
-// Date formatting utility
-function formatDate(iso) {
-  const d = new Date(iso);
-  return d.toLocaleDateString(undefined, {
-    day: "2-digit",
-    month: "short",
-    year: "numeric",
-  });
-}
+import formatDate from "./formatDate.js";
 
 // Main page logic
 document.addEventListener("DOMContentLoaded", function () {

--- a/assets/js/formatDate.js
+++ b/assets/js/formatDate.js
@@ -1,4 +1,4 @@
-function formatDate(iso) {
+export default function formatDate(iso) {
   const d = new Date(iso);
   return d.toLocaleDateString(undefined, {
     day: '2-digit',
@@ -6,3 +6,5 @@ function formatDate(iso) {
     year: 'numeric',
   });
 }
+
+if (typeof module !== 'undefined') module.exports = formatDate;

--- a/assets/js/package.json
+++ b/assets/js/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/tests/formatDate.test.js
+++ b/tests/formatDate.test.js
@@ -1,8 +1,8 @@
-const formatDate = require('../assets/js/formatDate');
 const assert = require('assert');
 const test = require('node:test');
 
-test('formatDate returns a non-empty string containing 2025', () => {
+test('formatDate returns a non-empty string containing 2025', async () => {
+  const { default: formatDate } = await import('../assets/js/formatDate.js');
   const result = formatDate('2025-07-15');
   assert.strictEqual(typeof result, 'string');
   assert.notStrictEqual(result.length, 0);


### PR DESCRIPTION
## Summary
- Export `formatDate` as an ES module while preserving CommonJS compatibility.
- Replace inline date formatter in `blog.js` with import from `formatDate.js`.
- Update unit test to dynamically import the shared module.
- Mark `assets/js` directory as type module for Node.

## Testing
- `npm test` *(fails: Failed to launch the browser process; libatk-1.0.so.0 missing, and ReferenceError: describe is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68953a1258188321b885dd82a8fee356