### PR TITLE
feat: cleanup old caches

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -21,6 +21,18 @@ self.addEventListener('install', (event) => {
   );
 });
 
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((cacheNames) =>
+      Promise.all(
+        cacheNames
+          .filter((cacheName) => cacheName !== CACHE_NAME)
+          .map((cacheName) => caches.delete(cacheName))
+      )
+    )
+  );
+});
+
 self.addEventListener('fetch', (event) => {
   event.respondWith(
     caches.match(event.request).then((response) => response || fetch(event.request))


### PR DESCRIPTION
## Summary
- remove outdated caches during service worker activation

## Testing
- `npm test` *(fails: Failed to launch the browser process - libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68953a12c23c8321bec4f00dfe9e1740