### PR TITLE
Move residual parallax logic into JS module

### DIFF
--- a/assets/js/parallax.js
+++ b/assets/js/parallax.js
@@ -48,4 +48,48 @@ if (document.fonts && document.fonts.ready) {
   document.fonts.ready.then(resizeParallax);
 }
 
+// Move interaction effects from inline scripts into this file
+window.addEventListener('DOMContentLoaded', () => {
+  const logoForeground = document.getElementById('logo-foreground');
+  const logoBackground = document.getElementById('logo-background');
+  if (logoForeground && logoBackground) {
+    logoForeground.addEventListener('mouseover', () => {
+      logoBackground.style.filter = 'invert(1)';
+    });
+    logoForeground.addEventListener('mouseout', () => {
+      logoBackground.style.filter = 'invert(0)';
+    });
+  }
+
+  const bass = document.getElementById('bassvictim-section');
+  if (bass) {
+    const lines = bass.querySelectorAll('.bassvictim_text p');
+    let revealTimeouts = [];
+    bass.addEventListener('mouseenter', () => {
+      revealTimeouts = [];
+      lines.forEach((p, i) => {
+        const timeoutId = setTimeout(() => {
+          p.classList.add('reveal');
+        }, i * 30);
+        revealTimeouts.push(timeoutId);
+      });
+    });
+    bass.addEventListener('mouseleave', () => {
+      revealTimeouts.forEach(clearTimeout);
+      revealTimeouts = [];
+      lines.forEach((p) => p.classList.remove('reveal'));
+    });
+  }
+
+  const pilleaterForeground = document.getElementById('pilleater-foreground');
+  const pilleaterBackground = document.getElementById('pilleater-background');
+  if (pilleaterForeground && pilleaterBackground) {
+    let flashed = false;
+    setInterval(() => {
+      pilleaterBackground.style.filter = flashed ? 'invert(0)' : 'invert(1)';
+      flashed = !flashed;
+    }, 140);
+  }
+});
+
 

--- a/index.html
+++ b/index.html
@@ -240,54 +240,5 @@
 
     </script>
 
-    <script>
-
-      const logoForeground = document.getElementById("logo-foreground");
-      const logoBackground = document.getElementById("logo-background");
-      logoForeground.addEventListener("mouseover", () => {
-        logoBackground.style.filter = "invert(1)";
-      });
-      logoForeground.addEventListener("mouseout", () => {
-        logoBackground.style.filter = "invert(0)";
-      });
-
-      // bassvictim hover effect
-      const bass = document.getElementById("bassvictim-section");
-      const lines = bass.querySelectorAll(".bassvictim_text p");
-
-      let revealTimeouts = [];
-
-      bass.addEventListener("mouseenter", () => {
-        revealTimeouts = []; // reset list
-        lines.forEach((p, i) => {
-          const timeoutId = setTimeout(() => {
-            p.classList.add("reveal");
-          }, i * 30);
-          revealTimeouts.push(timeoutId);
-        });
-      });
-
-      bass.addEventListener("mouseleave", () => {
-        // Cancel pending reveals
-        revealTimeouts.forEach(clearTimeout);
-        revealTimeouts = [];
-
-        // Instantly hide everything
-        lines.forEach((p) => p.classList.remove("reveal"));
-      });
-
-      // pilleater flash effect - constantly flash at interval
-      const pilleaterForeground = document.getElementById(
-        "pilleater-foreground"
-      );
-      const pilleaterBackground = document.getElementById(
-        "pilleater-background"
-      );
-      let flashed = false;
-      setInterval(() => {
-        pilleaterBackground.style.filter = flashed ? "invert(0)" : "invert(1)";
-        flashed = !flashed;
-      }, 140); // flash interval in ms
-    </script>
-  </body>
+      </body>
 </html>


### PR DESCRIPTION
## Summary
- move remaining parallax/hover effects from inline script in index.html into `assets/js/parallax.js`
- leave index.html free of parallax-specific inline JavaScript

## Testing
- `npm test` *(fails: formatDate is not a function; puppeteer missing shared libraries; describe is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b3691c04288321b1c1bfb37a8246ad