### PR TITLE
Remove JS parallax resizing and rely on CSS heights

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -56,8 +56,12 @@ body {
   top: 0;
   left: 0;
   width: 100%;
-  height: auto;
-  min-height: 200vh; /* fallback if JS fails */
+  height: 100vh;
+}
+
+/* Parallax section containers rely on fixed heights */
+.parallax-section {
+  height: 100vh;
 }
 
 /* Parallax background child */

--- a/assets/js/parallax.js
+++ b/assets/js/parallax.js
@@ -7,26 +7,6 @@ const bassvictimParallax = document.getElementById('bassvictim-section');
 // TODO add the pilleater section to parallax.
 // TODO add the pillsieat-overaly section to parallax
 
-function resizeParallax() {
-  const docHeight = Math.max(
-    document.body.scrollHeight,
-    document.documentElement.scrollHeight
-  );
-  const maxScrollY = docHeight - window.innerHeight;
-  const neededHeight = window.innerHeight + maxScrollY * 0.5;
-
-  parallaxBg.style.height = `${neededHeight}px`;
-  if (parallaxFg) {
-    parallaxFg.style.height = `${neededHeight}px`;
-  }
-  if (nettspendParallax) {
-    nettspendParallax.style.height = `${neededHeight}px`;
-  }
-   if (bassvictimParallax) {
-    bassvictimParallax.style.height = `${neededHeight}px`;
-  }
-}
-
 function updateParallax() {
   parallaxBg.style.transform = `translateY(${window.scrollY * -0.5}px)`;
   if (parallaxFg) {
@@ -52,12 +32,6 @@ window.addEventListener(
   },
   { passive: true }
 );
-
-window.addEventListener('load', resizeParallax);
-window.addEventListener('resize', resizeParallax);
-if (document.fonts && document.fonts.ready) {
-  document.fonts.ready.then(resizeParallax);
-}
 
 window.addEventListener('DOMContentLoaded', () => {
   const logoForeground = document.getElementById('logo-foreground');

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
       </a>
     </section>
 
-    <section id="bassvictim-section">
+    <section id="bassvictim-section" class="parallax-section">
       <a href="https://www.instagram.com/nepobabiesruntheunderground/">
         <div class="bassvictim-container">
           <img
@@ -95,7 +95,7 @@
       </a>
     </section>
 
-    <section id="nettspend-parallax">
+    <section id="nettspend-parallax" class="parallax-section">
       <img
         src="assets/images/nettspend.gif"
         alt="Animated Netspend meme"


### PR DESCRIPTION
## Summary
- simplify parallax script by removing runtime height calculations and resize event hooks
- define `.parallax` and new `.parallax-section` classes with fixed `100vh` height
- mark sections as `.parallax-section` to use CSS-based heights

## Testing
- `npm test` *(fails: formatDate is not a function; failed to launch the browser process: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b74cc79a608321a3013f688c3d7f68