### PR TITLE
Anchor parallax sections to their offsets

### DIFF
--- a/assets/js/parallax.js
+++ b/assets/js/parallax.js
@@ -7,16 +7,23 @@ const bassvictimParallax = document.getElementById('bassvictim-section');
 // TODO add the pilleater section to parallax.
 // TODO add the pillsieat-overaly section to parallax
 
+function applyParallax(element, speed) {
+  const offset = window.scrollY - element.offsetTop;
+  element.style.transform = `translateY(${offset * speed}px)`;
+}
+
 function updateParallax() {
-  parallaxBg.style.transform = `translateY(${window.scrollY * -0.5}px)`;
+  if (parallaxBg) {
+    applyParallax(parallaxBg, -0.5);
+  }
   if (parallaxFg) {
-    parallaxFg.style.transform = `translateY(${window.scrollY * -1}px)`;
+    applyParallax(parallaxFg, -1);
   }
   if (nettspendParallax) {
-    nettspendParallax.style.transform = `translateY(${window.scrollY * -0.25}px)`;
+    applyParallax(nettspendParallax, -0.25);
   }
   if (bassvictimParallax) {
-    bassvictimParallax.style.transform = `translateY(${window.scrollY * -0.35}px)`;
+    applyParallax(bassvictimParallax, -0.35);
   }
   ticking = false;
 }


### PR DESCRIPTION
## Summary
- calculate parallax movement relative to each section's offset instead of the global scroll position

## Testing
- `npm test` *(fails: formatDate is not a function; Failed to launch the browser process: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b755aa5a0883219309c243df9e0964