### PR TITLE
Fix parallax sections to avoid layout overlap

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -61,7 +61,19 @@ body {
 
 /* Parallax section containers rely on fixed heights */
 .parallax-section {
+  position: relative;
   height: 100vh;
+  overflow: hidden;
+}
+
+/* Child layer that receives parallax transform */
+.parallax-layer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  will-change: transform;
 }
 
 /* Parallax background child */

--- a/assets/js/parallax.js
+++ b/assets/js/parallax.js
@@ -1,14 +1,18 @@
 const parallaxBg = document.querySelector('.parallax-bg');
 const parallaxFg = document.querySelector('.parallax-fg');
-const nettspendParallax = document.getElementById('nettspend-parallax');
-const bassvictimParallax = document.getElementById('bassvictim-section');
+const nettspendContainer = document.getElementById('nettspend-parallax');
+const nettspendParallax =
+  nettspendContainer ? nettspendContainer.querySelector('.parallax-layer') : null;
+const bassvictimContainer = document.getElementById('bassvictim-section');
+const bassvictimParallax =
+  bassvictimContainer ? bassvictimContainer.querySelector('.parallax-layer') : null;
 
 
 // TODO add the pilleater section to parallax.
 // TODO add the pillsieat-overaly section to parallax
 
-function applyParallax(element, speed) {
-  const offset = window.scrollY - element.offsetTop;
+function applyParallax(element, speed, container = element) {
+  const offset = window.scrollY - container.offsetTop;
   element.style.transform = `translateY(${offset * speed}px)`;
 }
 
@@ -19,11 +23,11 @@ function updateParallax() {
   if (parallaxFg) {
     applyParallax(parallaxFg, -1);
   }
-  if (nettspendParallax) {
-    applyParallax(nettspendParallax, -0.25);
+  if (nettspendParallax && nettspendContainer) {
+    applyParallax(nettspendParallax, -0.25, nettspendContainer);
   }
-  if (bassvictimParallax) {
-    applyParallax(bassvictimParallax, -0.35);
+  if (bassvictimParallax && bassvictimContainer) {
+    applyParallax(bassvictimParallax, -0.35, bassvictimContainer);
   }
   ticking = false;
 }
@@ -52,7 +56,7 @@ window.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  const bass = document.getElementById('bassvictim-section');
+  const bass = bassvictimContainer;
   if (bass) {
     const lines = bass.querySelectorAll('.bassvictim_text p');
     let revealTimeouts = [];

--- a/index.html
+++ b/index.html
@@ -66,55 +66,59 @@
     </section>
 
     <section id="bassvictim-section" class="parallax-section">
-      <a href="https://www.instagram.com/nepobabiesruntheunderground/">
-        <div class="bassvictim-container">
-          <img
-            src="assets/images/bassvictim.png"
-            class="background_bassvictim"
-            alt="Bassvictim music artist 'Makes You Wonder' single cover"
-          />
-          <img
-            src="assets/images/bassvictim_overlay.png"
-            class="overlay_bassvictim"
-            alt=""
-            aria-hidden="true"
-          />
-          <div class="bassvictim_text">
-            <p>INSTAGRAM</p>
-            <p>INSTAGRAM</p>
-            <p>INSTAGRAM</p>
-            <p>INSTAGRAM</p>
-            <p>INSTAGRAM</p>
-            <p>INSTAGRAM</p>
-            <p>INSTAGRAM</p>
-            <p>INSTAGRAM</p>
-            <p>INSTAGRAM</p>
-            <p>INSTAGRAM</p>
+      <div class="parallax-layer">
+        <a href="https://www.instagram.com/nepobabiesruntheunderground/">
+          <div class="bassvictim-container">
+            <img
+              src="assets/images/bassvictim.png"
+              class="background_bassvictim"
+              alt="Bassvictim music artist 'Makes You Wonder' single cover"
+            />
+            <img
+              src="assets/images/bassvictim_overlay.png"
+              class="overlay_bassvictim"
+              alt=""
+              aria-hidden="true"
+            />
+            <div class="bassvictim_text">
+              <p>INSTAGRAM</p>
+              <p>INSTAGRAM</p>
+              <p>INSTAGRAM</p>
+              <p>INSTAGRAM</p>
+              <p>INSTAGRAM</p>
+              <p>INSTAGRAM</p>
+              <p>INSTAGRAM</p>
+              <p>INSTAGRAM</p>
+              <p>INSTAGRAM</p>
+              <p>INSTAGRAM</p>
+            </div>
           </div>
-        </div>
-      </a>
+        </a>
+      </div>
     </section>
 
     <section id="nettspend-parallax" class="parallax-section">
-      <img
-        src="assets/images/nettspend.gif"
-        alt="Animated Netspend meme"
-        class="drankgif drankdrankdrank"
-      />
-      <img
-        src="assets/images/nettspend_overlay.png"
-        class="drankdrankdrank"
-        alt=""
-        aria-hidden="true"
-      />
-      <a href="https://www.last.fm/user/TheTexta" aria-label="TheTexta on Last.fm">
+      <div class="parallax-layer">
+        <img
+          src="assets/images/nettspend.gif"
+          alt="Animated Netspend meme"
+          class="drankgif drankdrankdrank"
+        />
         <img
           src="assets/images/nettspend_overlay.png"
-          class="drankhue drankdrankdrank"
+          class="drankdrankdrank"
           alt=""
           aria-hidden="true"
         />
-      </a>
+        <a href="https://www.last.fm/user/TheTexta" aria-label="TheTexta on Last.fm">
+          <img
+            src="assets/images/nettspend_overlay.png"
+            class="drankhue drankdrankdrank"
+            alt=""
+            aria-hidden="true"
+          />
+        </a>
+      </div>
     </section>
 
     


### PR DESCRIPTION
## Summary
- Keep parallax sections in normal flow by wrapping content in an absolutely-positioned layer that receives the scroll transform.
- Style new `.parallax-layer` and update `.parallax-section` for relative positioning and overflow control.
- Refactor parallax script to translate child layers relative to their parent sections.

## Testing
- `npm test` *(fails: formatDate is not a function; puppeteer missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b75b7f7ac483218a83f0f0ca034cb4