### PR TITLE
Allow parallax sections to grow with content

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -59,10 +59,10 @@ body {
   height: 100vh;
 }
 
-/* Parallax section containers rely on fixed heights */
+/* Parallax sections can grow with their content */
 .parallax-section {
   position: relative;
-  height: 100vh;
+  min-height: 100vh;
   overflow: hidden;
 }
 


### PR DESCRIPTION
## Summary
- Let parallax sections expand beyond 100vh so taller content is visible while keeping parallax layers contained

## Testing
- `npm test` *(fails: formatDate is not a function; Puppeteer missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b75ca7cca48321921a699c3c03515b