### PR TITLE
Use viewport-based offset for parallax calculations

### DIFF
--- a/assets/js/parallax.js
+++ b/assets/js/parallax.js
@@ -12,7 +12,7 @@ const bassvictimParallax =
 // TODO add the pillsieat-overaly section to parallax
 
 function applyParallax(element, speed, container = element) {
-  const offset = window.scrollY - container.offsetTop;
+  const offset = container.getBoundingClientRect().top;
   element.style.transform = `translateY(${offset * speed}px)`;
 }
 


### PR DESCRIPTION
## Summary
- compute parallax offsets using `getBoundingClientRect().top` instead of `offsetTop`

## Testing
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b75e4322a08321bc78f794b7c6fc45