### PR TITLE
Add basic service worker

### DIFF
--- a/index.html
+++ b/index.html
@@ -337,5 +337,12 @@
         }px`;
       });
     </script>
+    <script>
+      if ("serviceWorker" in navigator) {
+        window.addEventListener("load", () => {
+          navigator.serviceWorker.register("sw.js");
+        });
+      }
+    </script>
   </body>
 </html>

--- a/me.html
+++ b/me.html
@@ -59,4 +59,11 @@
         { once: true }
       );
   </script>
+  <script>
+    if ("serviceWorker" in navigator) {
+      window.addEventListener("load", () => {
+        navigator.serviceWorker.register("sw.js");
+      });
+    }
+  </script>
 </html>

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,19 @@
+const CACHE_NAME = 'nbu-cache-v1';
+const ASSETS = ['.', 'index.html', 'me.html'];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('fetch', (event) => {
+  event.respondWith(
+    caches.match(event.request).then((response) => response || fetch(event.request))
+  );
+});
+


### PR DESCRIPTION
## Summary
- add minimal service worker that precaches core pages and serves cached responses
- register service worker on main pages for offline capability

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd4832cc30832194ac149ced63fb3e